### PR TITLE
More specific @match page & No longer re-declare i

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@
 // @author          TalkLounge (https://github.com/TalkLounge)
 // @namespace       https://github.com/TalkLounge/cleanup-youtube-search
 // @license         MIT
-// @match           https://www.youtube.com/*
+// @match           https://www.youtube.com/results?search_query*
 // @grant           none
 // ==/UserScript==
 
@@ -25,7 +25,7 @@
         }
 
         shelfs = document.getElementsByTagName("ytd-horizontal-card-list-renderer");
-        for (var i = 0; i < shelfs.length; i++) {
+        for (i = 0; i < shelfs.length; i++) {
             shelfs[i].remove();
         }
     }


### PR DESCRIPTION
Now matches only the youtube.com/results?search_query page, since it only needs to run on that page.
i is already declared, so it doesn't need to be re-declared in the second for-loop.